### PR TITLE
Add code examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ primesieve-ruby
 ===============
 [![Gem Version](https://badge.fury.io/rb/primesieve.svg)](http://badge.fury.io/rb/primesieve)
 
-Ruby bindings (gem wrapper) for the [primesieve](https://github.com/kimwalisch/primesieve) C++ library. Generates primes orders of magnitude faster than any pure Ruby code.
+Ruby bindings (gem wrapper) for the [primesieve C++ library](https://github.com/kimwalisch/primesieve). Generates primes orders of magnitude faster than any pure Ruby code.
 
 Installing
 ----------

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ require 'primesieve'
 # Generate an array with the primes inside [0, 20]
 primes = Primesieve.generate_primes(0, 20)
 
-# Generate an array of the first 10 primes starting at 0
+# Generate an array with the first 10 primes starting at 0
 primes = Primesieve.generate_n_primes(10, 0)
 
 # Get the 10th prime

--- a/README.md
+++ b/README.md
@@ -1,35 +1,70 @@
-primesieve
-==========
+primesieve-ruby
+===============
 [![Gem Version](https://badge.fury.io/rb/primesieve.svg)](http://badge.fury.io/rb/primesieve)
 
-primesieve is a gem wrapper for the [primesieve](http://primesieve.org/) prime number generator
+Ruby bindings for the primesieve C/C++ library. Generates primes orders of magnitude faster than any pure Ruby code.  Features:
+
+* Generate a list of primes
+* Count primes and [prime k-tuplets](https://en.wikipedia.org/wiki/Prime_k-tuple)
+* Print primes and prime k-tuplets
+* Find the nth prime
 
 Installing
-==========
+----------
+
 * Get primesieve
-  * On OSX: `brew install primesieve`
-  * [download here](http://primesieve.org/downloads/)
-  * [follow instructions to build from source](http://primesieve.org/build.html)
+  * __OS X:__ `brew install primesieve`
+  * [Build from source](https://github.com/kimwalisch/primesieve#build-instructions-unix-like-oses)
 
 * Get the primesieve gem
   * `gem install primesieve`
--or-
+__-or-__
   * add `gem 'primesieve'` to your Gemfile and run `bundle install`
 
 Usage
-=====
-First `require 'primesieve'`
-Then you have access to the `Primesieve` module which has all the functions of primesieve documented [here](http://primesieve.org/api/primesieve_8h.html) with the following exceptions:
-* functions requiring a type cannot be passed a type and will default to `UINT64_PRIMES`
-* functions requiring a `size_t *` cannot be passed that arg (an appropriatly sized Ruby array will be returned)
-* the function names leave off the `primesieve_` prefix
-  * for example, to call `primesieve_generate_primes`, use `Primesieve.generate_primes(start, stop)`
-* the functions `callback_primes` and `parallel_callback_primes` take a block rather than a callback function
-* `primesieve_free` is not implemented
+-----
 
-But how fast is it?
-===================
-Ruby 2.1.3 [Prime](http://www.ruby-doc.org/stdlib-2.0.0/libdoc/prime/rdoc/Prime.html) module vs. primesieve to generate the first 10,000,000 primes
+The syntax of the primesieve Ruby bindings is nearly identical to the
+syntax of the primesieve C library.
+
+```Ruby
+require 'primesieve'
+
+# Generate an array with the primes inside [0, 20]
+primes = Primesieve.generate_primes(0, 20)
+
+# Generate an array of the first 10 primes starting at 0
+primes = Primesieve.generate_n_primes(10, 0)
+
+# Get the 10th prime
+puts Primesieve.nth_prime(10, 0);
+
+# Count the primes below 10**9
+puts Primesieve.count_primes(0, 10**9)
+```
+
+Here is a [list of all available functions](ext/primesieve/extconf.rb).
+
+Multi-threading
+---------------
+
+Counting primes and prime k-tuplets and finding the nth prime can be done in parallel using multiple threads, just use the ```parallel_``` prefix and primesieve will use all your CPU cores.
+
+```Ruby
+require 'primesieve'
+
+# Count the primes below 10**11 using all CPU cores
+puts Primesieve.parallel_count_primes(0, 10**11)
+
+# Find the 10**10th prime (starting at 0) using all CPU cores
+puts Primesieve.parallel_nth_prime(10**10, 0)
+```
+
+How fast is it?
+---------------
+
+Ruby 2.1.3 [Prime](http://www.ruby-doc.org/stdlib-2.0.0/libdoc/prime/rdoc/Prime.html) module vs. primesieve to generate the first 10,000,000 primes.
+
 ```
            user     system      total        real
 Ruby  26.680000   3.930000  30.610000 ( 30.621654)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ primesieve-ruby
 ===============
 [![Gem Version](https://badge.fury.io/rb/primesieve.svg)](http://badge.fury.io/rb/primesieve)
 
-Ruby bindings for the primesieve C/C++ library. Generates primes orders of magnitude faster than any pure Ruby code.  Features:
+Ruby bindings (gem wrapper) for the primesieve C/C++ library. Generates primes orders of magnitude faster than any pure Ruby code.  Features:
 
 * Generate a list of primes
 * Count primes and [prime k-tuplets](https://en.wikipedia.org/wiki/Prime_k-tuple)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@ primesieve-ruby
 ===============
 [![Gem Version](https://badge.fury.io/rb/primesieve.svg)](http://badge.fury.io/rb/primesieve)
 
-Ruby bindings (gem wrapper) for the primesieve C/C++ library. Generates primes orders of magnitude faster than any pure Ruby code.  Features:
-
-* Generate a list of primes
-* Count primes and [prime k-tuplets](https://en.wikipedia.org/wiki/Prime_k-tuple)
-* Print primes and prime k-tuplets
-* Find the nth prime
+Ruby bindings (gem wrapper) for the [primesieve](https://github.com/kimwalisch/primesieve) C++ library. Generates primes orders of magnitude faster than any pure Ruby code.
 
 Installing
 ----------
@@ -25,7 +20,7 @@ Usage
 -----
 
 The syntax of the primesieve Ruby bindings is nearly identical to the
-syntax of the primesieve C library.
+syntax of the primesieve C++ library.
 
 ```Ruby
 require 'primesieve'


### PR DESCRIPTION
Please merge my README.md changes.

I have added code examples and I have also simplified the Usage section because I think the target audience of this gem wrapper are students who want to get started quickly and who will mainly use the generate_primes() method.
