### PR TITLE
Remove deprecated parallel_callback_primes()

### DIFF
--- a/ext/primesieve/extconf.rb
+++ b/ext/primesieve/extconf.rb
@@ -41,7 +41,6 @@ fns = [
  'primesieve_print_quintuplets',
  'primesieve_print_sextuplets',
  'primesieve_callback_primes',
- 'primesieve_parallel_callback_primes',
  'primesieve_get_sieve_size',
  'primesieve_get_num_threads',
  'primesieve_get_max_stop',

--- a/ext/primesieve/primesieve-ruby.c
+++ b/ext/primesieve/primesieve-ruby.c
@@ -127,13 +127,6 @@ static void parallel_callback_fn(uint64_t prime, int thread_id) {
   return;
 }
 
-static VALUE parallel_callback_primes(VALUE self, VALUE start, VALUE stop) {
-  if (!rb_block_given_p())
-    rb_raise(rb_eArgError, "Expected block");
-  primesieve_parallel_callback_primes(NUM2ULL(start), NUM2ULL(stop), parallel_callback_fn);
-  return Qnil;
-}
-
 static VALUE get_sieve_size(VALUE self) {
   return INT2NUM(primesieve_get_sieve_size());
 }
@@ -186,7 +179,6 @@ void Init_primesieve() {
   rb_define_module_function(mPrimesieve, "print_quintuplets", print_quintuplets, 2);
   rb_define_module_function(mPrimesieve, "print_sextuplets", print_sextuplets, 2);
   rb_define_module_function(mPrimesieve, "callback_primes", callback_primes, 2);
-  rb_define_module_function(mPrimesieve, "parallel_callback_primes", parallel_callback_primes, 2);
   rb_define_module_function(mPrimesieve, "get_sieve_size", get_sieve_size, 0);
   rb_define_module_function(mPrimesieve, "get_num_threads", get_num_threads, 0);
   rb_define_module_function(mPrimesieve, "get_max_stop", get_max_stop, 0);

--- a/primesieve.gemspec
+++ b/primesieve.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'primesieve'
-  s.version     = '1.0.0'
-  s.date        = '2016-07-14'
+  s.version     = '1.1.0'
+  s.date        = '2015-12-10'
   s.description = 'A wrapper for the primesieve C prime number generator'
   s.summary     = 'A wrapper for the primesieve lib'
   s.authors     = ['Robert Looby']


### PR DESCRIPTION
Hi,

I have cleaned up the C/C++ API of primesieve and removed the crazy parallel_callback_primes() functions. I will publish the new primesieve-5.6.0 in a week or so.

Hence I proactively send you a pull request which removes parallel_callback_primes()  from primesieve-ruby.

Best regards,
Kim
